### PR TITLE
update AMQP url

### DIFF
--- a/template/docker-compose.env
+++ b/template/docker-compose.env
@@ -13,7 +13,7 @@ TRANSPORTER=redis://redis:6379
 TRANSPORTER=mqtt://mqtt:1883
 {{/if_eq}}      
 {{#if_eq transporter "AMQP"}}
-TRANSPORTER=amqp://rabbit:5672
+TRANSPORTER=amqp://amqp:5672
 {{/if_eq}}      
 {{#if_eq transporter "STAN"}}
 TRANSPORTER=stan://stan:4222


### PR DESCRIPTION
"rabbit" does not exist in docker-compose. RabbitMQ's name is "amqp" in docker-compose file.

TRANSPORTER=amqp://rabbit:5672 to TRANSPORTER=amqp://amqp:5672
