### PR TITLE
resolved Lint errors

### DIFF
--- a/template/mixins/db.mixin.ts
+++ b/template/mixins/db.mixin.ts
@@ -57,6 +57,7 @@ class Connection implements Partial<ServiceSchema>, ThisType<Service>{
 	public start(){
 			if (process.env.MONGO_URI) {
 				// Mongo adapter
+				// eslint-disable-next-line @typescript-eslint/no-var-requires
 				const   MongoAdapter = require("moleculer-db-adapter-mongo");
 
 				this.schema.adapter = new MongoAdapter(process.env.MONGO_URI);

--- a/template/moleculer.config.ts
+++ b/template/moleculer.config.ts
@@ -59,7 +59,7 @@ const brokerConfig: BrokerOptions = {
 	// More info: https://moleculer.services/docs/0.14/networking.html
 	// Note: During the development, you don't need to define it because all services will be loaded locally.
 	// In production you can set it via `TRANSPORTER=nats://localhost:4222` environment variable.
-	transporter: null,{{#if needTransporter}} //"{{transporter}}"{{/if}}
+	transporter: null,{{#if needTransporter}} // "{{transporter}}"{{/if}}
 
 	// Define a cacher.
 	// More info: https://moleculer.services/docs/0.14/caching.html


### PR DESCRIPTION
when using the yarn lint command, there were 2 errors in the lint 
✖ 2 problems (2 errors, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option. 

these errors have been corrected