### PR TITLE
Using NODE_ENV variable

### DIFF
--- a/template/mixins/db.mixin.ts
+++ b/template/mixins/db.mixin.ts
@@ -62,7 +62,7 @@ export default class Connection implements Partial<ServiceSchema>, ThisType<Serv
 			const   MongoAdapter = require("moleculer-db-adapter-mongo");
 			this.schema.adapter = new MongoAdapter(process.env.MONGO_URI);
 			this.schema.collection = this.collection;
-		} else if (process.env.TEST) {
+		} else if (process.env.NODE_ENV === 'test') {
 			// NeDB memory adapter for testing
 			// @ts-ignore
 			this.schema.adapter = new DbService.MemoryAdapter();

--- a/template/mixins/db.mixin.ts
+++ b/template/mixins/db.mixin.ts
@@ -62,7 +62,7 @@ export default class Connection implements Partial<ServiceSchema>, ThisType<Serv
 			const   MongoAdapter = require("moleculer-db-adapter-mongo");
 			this.schema.adapter = new MongoAdapter(process.env.MONGO_URI);
 			this.schema.collection = this.collection;
-		} else if (process.env.NODE_ENV === 'test') {
+		} else if (process.env.NODE_ENV === "test") {
 			// NeDB memory adapter for testing
 			// @ts-ignore
 			this.schema.adapter = new DbService.MemoryAdapter();

--- a/template/test/integration/products.service.spec.ts
+++ b/template/test/integration/products.service.spec.ts
@@ -1,7 +1,5 @@
 "use strict";
 
-process.env.TEST = "true";
-
 import { ServiceBroker } from "moleculer";
 import TestService from "../../services/products.service";
 

--- a/template/test/unit/mixins/db.mixin.spec.ts
+++ b/template/test/unit/mixins/db.mixin.spec.ts
@@ -1,7 +1,5 @@
 "use strict";
 
-process.env.TEST = "true";
-
 import { ServiceBroker } from "moleculer";
 import DbService from "moleculer-db";
 import DbMixin from "../../../mixins/db.mixin";

--- a/template/test/unit/services/products.spec.ts
+++ b/template/test/unit/services/products.spec.ts
@@ -1,7 +1,5 @@
 "use strict";
 
-process.env.TEST = "true";
-
 import { Context, Errors, ServiceBroker } from "moleculer";
 import TestService from "../../../services/products.service";
 


### PR DESCRIPTION
In this PR:
- [x] Improved test mode detection by using `NODE_ENV` variable instead of `TEST` variable. See https://jestjs.io/docs/en/environment-variables