### PR TITLE
Fix 52

### DIFF
--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -16,4 +16,4 @@ RUN npm run build \
  && npm prune
 
 # Start server
-CMD ["node", "./node_modules/moleculer/bin/moleculer-runner.js"]
+CMD ["npm", "start"]

--- a/template/docker-compose.env
+++ b/template/docker-compose.env
@@ -2,7 +2,6 @@ NAMESPACE=
 LOGGER=true
 LOGLEVEL=info
 SERVICEDIR=dist/services
-CONFIG=dist
 
 {{#if_eq transporter "NATS"}}
 TRANSPORTER=nats://nats:4222

--- a/template/package.json
+++ b/template/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "tsc --build tsconfig.json",
     "dev": "ts-node ./node_modules/moleculer/bin/moleculer-runner.js --hot --repl --config moleculer.config.ts services/**/*.service.ts",
-    "start": "moleculer-runner",
+    "start": "moleculer-runner --config dist/moleculer.config.js",
     "cli": "moleculer connect {{transporter}}",
     "ci": "jest --watch",
     "test": "jest --coverage"{{#lint}},


### PR DESCRIPTION
This PR fixes https://github.com/moleculerjs/moleculer-template-project-typescript/issues/52

When running `docker-compose up` moleculer-runner ignored the `moleculer.config.ts` file and always used default configs. This happens because currently it's not possible to declare via env variables the location of config file (for more info see https://github.com/moleculerjs/moleculer/issues/921).

To fix this I've changed `npm start` in `package.json` to explicitly inform the runner about the location of the `moleculer.config`, which is placed in `dist` folder after running `npm build`. I've also changed `Dockerfile` to use `npm start` instead of using molculer-runner with default configs