### PR TITLE
fix npm args problem in package script

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -4,7 +4,7 @@
   "description": "My Moleculer-based microservices project",
   "scripts": {
     "build": "tsc --build tsconfig.json",
-    "dev": "ts-node ./node_modules/moleculer/bin/moleculer-runner.js --hot --repl --config moleculer.config.ts services/**/*.service.ts",
+    "dev": "ts-node ./node_modules/moleculer/bin/moleculer-runner.js --hot --repl --config moleculer.config.ts 'services/**/*.service.ts'",
     "start": "moleculer-runner --config dist/moleculer.config.js",
     "cli": "moleculer connect {{transporter}}",
     "ci": "jest --watch",


### PR DESCRIPTION
With some problem, npm script will have some weird behaviour in wildcard.

For example:
dir:
```
├── README.md
├── gateway.service.ts
├── test.service.ts
└── user
    └── users.service.ts
```
process with npm `npm run dev` => services/user/users.service.ts
process origin script `ts-node ./node_modules/moleculer/bin/moleculer-runner.js --hot --repl --config moleculer.config.ts 'services/**/*.service.ts' ` => services/gateway.service.ts services/test.service.ts services/user/users.service.ts

add a single quotes to ensure pass origin glob string to runner.js self. without external environment

![image](https://user-images.githubusercontent.com/6964737/123034032-60e8b100-d41b-11eb-98c4-03c7ee1c8023.png)
